### PR TITLE
Add subscription by namespace

### DIFF
--- a/openapi-spec.yaml
+++ b/openapi-spec.yaml
@@ -198,8 +198,12 @@ components:
       description: Data to register a notification when a discovery is performed
       type: object
       required:
+        - namespace
         - endpoint
       properties:
+        namespace:
+          description: The namespace name to be subscribed to.
+          type: string 
         endpoint:
           description: An endpoint, where a notification will be sent to
           type: string

--- a/src/pds/api/controllers/default.py
+++ b/src/pds/api/controllers/default.py
@@ -95,7 +95,7 @@ def discover_update(body: UpdateInput = None):
             result = json.loads(save_response.text)
             # TODO: notifications can be run in background
             # TODO: handle failed subscribers
-            failed_subscribers = Notifier.notify_subscribers()
+            failed_subscribers = Notifier.notify_subscribers(update_input.namespace)
             return UpdateOutput(result.get("aadmuri"), result.get("rmuri")), 200
         else:
             return save_response.text, save_response.status_code

--- a/src/pds/api/utils/notifier.py
+++ b/src/pds/api/utils/notifier.py
@@ -24,9 +24,11 @@ class Notifier:
         cls.subscribers.append(subscriber)
 
     @classmethod
-    def notify_subscribers(cls):
+    def notify_subscribers(cls, namespace: str):
         failed_subscribers = []
         for subscriber in cls.subscribers:
+            if namespace != subscriber.namespace:
+                continue
             try:
                 response = requests.post(subscriber.endpoint,
                               json=subscriber.payload,


### PR DESCRIPTION
In this PR, a subscription by namespace is introduced. The notifications are sent to the subscribers only when the namespaces (subscription and KB update) match.