### PR TITLE
Bump iac-modules

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,7 +185,7 @@ pipeline {
                     python3 -m pip install --upgrade pip
                     python3 -m pip install opera==0.6.4 openstacksdk==0.52.0 docker
                     rm -r -f pds-openstack/modules/
-                    git clone -b 3.3.0 https://github.com/SODALITE-EU/iac-modules.git pds-openstack/modules/
+                    git clone -b 3.4.1 https://github.com/SODALITE-EU/iac-modules.git pds-openstack/modules/
                     ansible-galaxy install -r pds-openstack/modules/requirements.yml --force
                     cp ${ca_crt_file} pds-openstack/modules/docker/artifacts/ca.crt
                     cp ${ca_crt_file} pds-openstack/modules/misc/tls/artifacts/ca.crt

--- a/pds-openstack/prerequisites.sh
+++ b/pds-openstack/prerequisites.sh
@@ -12,7 +12,7 @@ ansible-galaxy install geerlingguy.repo-epel,3.0.0 --force
 echo
 echo "Cloning modules"
 rm -r -f modules/
-git clone -b 3.1.0 https://github.com/SODALITE-EU/iac-modules.git modules/
+git clone -b 3.4.1 https://github.com/SODALITE-EU/iac-modules.git modules/
 
 echo "Please enter email for SODALITE certificate: "
 read EMAIL_INPUT


### PR DESCRIPTION
This contribution bumps SODALITE iac-modules, used in CI/CD pipeline and with openstack-blueprint. New modules' version provides pip docker bugfix for deployment to centos7 distribution